### PR TITLE
Update level_generator.py

### DIFF
--- a/brownies/BNL/restools/level_generator.py
+++ b/brownies/BNL/restools/level_generator.py
@@ -311,6 +311,7 @@ def unfoldThenRefoldLevelSequence(
         invFakeCDF.plot()  # title='lookup table')
 
     # We'll add that back using the real level density.  The "refolds" back in the correct secular variation.
+    xList[-1] = 1.0
     result = [offset + invFakeCDF.evaluate(x) for x in xList]
     result.sort()
 


### PR DESCRIPTION
I noticed an issue in where "invFakeCDF" in "level_generator.py" would fail to evaluate due to what I presume to be floating point arithmetic errors in "xList". My fix was simply forcing the last entry in xList to be 1.0, which seems to be the case anyway.